### PR TITLE
[#4wgn1x] - Added sort by Level 

### DIFF
--- a/src/main/java/com/arqaam/logframelab/controller/IndicatorController.java
+++ b/src/main/java/com/arqaam/logframelab/controller/IndicatorController.java
@@ -25,14 +25,14 @@ import java.util.*;
 
 @CrossOrigin(origins = "*")
 @RestController
-@Api(tags = "Indicator", produces = MediaType.APPLICATION_JSON_VALUE)
+@Api(tags = "Indicator")
 public class IndicatorController implements Logging {
 
     @Autowired
-    IndicatorService indicatorService;
+    private IndicatorService indicatorService;
 
     @ResponseStatus(HttpStatus.OK)
-    @PostMapping(value = "/indicator/upload")
+    @PostMapping(value = "/indicator/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "${IndicatorController.handleFileUpload.value}", nickname = "handleFileUpload", response = IndicatorResponse.class, responseContainer = "List")
     @ApiResponses({
             @ApiResponse(code = 200, message = "File was uploaded", response = IndicatorResponse.class, responseContainer = "List"),
@@ -46,8 +46,8 @@ public class IndicatorController implements Logging {
         return indicatorService.extractIndicatorsFromWordFile(tmpFilePath);
     }
 
-    @PostMapping("/indicator/download")
-    @ApiOperation(value = "${IndicatorController.downloadIndicators.value}", nickname = "handleFileUpload", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/indicator/download", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @ApiOperation(value = "${IndicatorController.downloadIndicators.value}", nickname = "handleFileUpload")
     @ApiResponses({
             @ApiResponse(code = 200, message = "File was uploaded"),
             @ApiResponse(code = 500, message = "File failed to upload", response = Error.class)

--- a/src/main/java/com/arqaam/logframelab/service/IndicatorService.java
+++ b/src/main/java/com/arqaam/logframelab/service/IndicatorService.java
@@ -98,6 +98,19 @@ public class IndicatorService implements Logging {
                         }
                     }
                 }
+                if(!result.isEmpty()) {
+                    // Sort by Level
+                    //TODO fix this static strings
+                    result = result.stream().sorted((o1, o2) -> {
+                        if (o1.getLevel().equals(o2.getLevel())) return 0;
+                        if (o1.getLevel().equals("IMPACT")) return -1;
+                        if (o2.getLevel().equals("IMPACT")) return 1;
+                        if (o1.getLevel().equals("OUTCOME")) return -1; 
+                        if (o2.getLevel().equals("OUTCOME")) return 1;
+                        if (o1.getLevel().equals("OUTPUT")) return -1;
+                        return 1;
+                    }).collect(Collectors.toList());
+                }
             } catch (JAXBException e) {
                 e.printStackTrace();
             } catch (XPathBinderAssociationIsPartialException e) {

--- a/src/test/java/com/arqaam/logframelab/service/IndicatorServiceTest.java
+++ b/src/test/java/com/arqaam/logframelab/service/IndicatorServiceTest.java
@@ -171,30 +171,6 @@ public class IndicatorServiceTest {
     void importIndicators() {
     }
 
-    private List<Indicator> createListIndicator() {
-        List<String> keywordList = new ArrayList<>();
-        keywordList.add("var");
-        keywordList.add("template");
-        keywordList.add("economy");
-
-        List<Indicator> list = new ArrayList<>();
-        for (int i = 1; i < 4; i++) {
-            list.add(Indicator.builder()
-                    .id((long) i)
-                    .level(Level.builder()
-                            .id(1L)
-                            .color("color")
-                            .name("IMPACT")
-                            .description("Description")
-                            .templateVar("templatevar").build())
-                    .description("Description")
-                    .name("Name")
-                    .keywordsList(keywordList)
-                    .build());
-        }
-        return list;
-    }
-
     private List<Indicator> mockIndicatorList() {
         Level level1 = new Level(1L, "OUTPUT", "OUTPUT", "{output}", "green");
         Level level2 = new Level(2L, "OUTCOME", "OUTCOME", "{outcomes}", "red");


### PR DESCRIPTION
IMPACT > OUTCOME > OUTPUT > OTHER OUTCOMES

will fix the strings when I rearrange the code. I think the ids of the levels should be in this order, in the database, so that its easier to compare.