### PR TITLE
Feature - Auto-extend JWT When Close To Expiration

### DIFF
--- a/src/main/java/com/arqaam/logframelab/configuration/security/WebSecurityConfiguration.java
+++ b/src/main/java/com/arqaam/logframelab/configuration/security/WebSecurityConfiguration.java
@@ -2,6 +2,7 @@ package com.arqaam.logframelab.configuration.security;
 
 import com.arqaam.logframelab.configuration.security.jwt.JwtAuthFilter;
 import com.arqaam.logframelab.configuration.security.jwt.JwtAuthenticationEntryPoint;
+import com.arqaam.logframelab.configuration.security.jwt.JwtRefreshFilter;
 import com.arqaam.logframelab.repository.NoOp;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -35,14 +36,18 @@ public class WebSecurityConfiguration  extends WebSecurityConfigurerAdapter  {
 
   private final JwtAuthFilter jwtAuthFilter;
 
+  private final JwtRefreshFilter jwtRefreshFilter;
+
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
   public WebSecurityConfiguration(
       @Qualifier("arqaamUserDetailsService") UserDetailsService userDetailsService,
       JwtAuthFilter jwtAuthFilter,
+      JwtRefreshFilter jwtRefreshFilter,
       JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) {
     this.userDetailsService = userDetailsService;
     this.jwtAuthFilter = jwtAuthFilter;
+    this.jwtRefreshFilter = jwtRefreshFilter;
     this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
   }
 
@@ -93,6 +98,7 @@ public class WebSecurityConfiguration  extends WebSecurityConfigurerAdapter  {
         .authenticated();
 
     http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+    http.addFilterAfter(jwtRefreshFilter, UsernamePasswordAuthenticationFilter.class);
   }
 
 }

--- a/src/main/java/com/arqaam/logframelab/configuration/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/arqaam/logframelab/configuration/security/jwt/JwtAuthFilter.java
@@ -4,7 +4,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -41,7 +40,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
       FilterChain filterChain)
       throws ServletException, IOException {
     try {
-      String jwt = getJwtFromRequest(httpServletRequest);
+      String jwt = JwtUtil.getJwtFromRequest(httpServletRequest, jwtTokenProvider);
 
       if (StringUtils.isNotBlank(jwt) && jwtTokenProvider.isTokenValid(jwt)) {
         String username = jwtTokenProvider.getUsernameFromJws(jwt);
@@ -58,14 +57,5 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     }
 
     filterChain.doFilter(httpServletRequest, httpServletResponse);
-  }
-
-  private String getJwtFromRequest(HttpServletRequest request) {
-    String bearerToken = request.getHeader(jwtTokenProvider.getTokenHeader());
-    if (StringUtils.isNotBlank(bearerToken) && bearerToken.startsWith(jwtTokenProvider.getTokenHeaderPrefix())) {
-      return StringUtils.remove(bearerToken, jwtTokenProvider.getTokenHeaderPrefix());
-    }
-
-    return null;
   }
 }

--- a/src/main/java/com/arqaam/logframelab/configuration/security/jwt/JwtRefreshFilter.java
+++ b/src/main/java/com/arqaam/logframelab/configuration/security/jwt/JwtRefreshFilter.java
@@ -1,0 +1,47 @@
+package com.arqaam.logframelab.configuration.security.jwt;
+
+import com.arqaam.logframelab.model.persistence.auth.User;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.Date;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtRefreshFilter extends OncePerRequestFilter {
+
+  private static final long ONE_HOUR = 60 * 60 * 60L;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  public JwtRefreshFilter(JwtTokenProvider jwtTokenProvider) {
+    this.jwtTokenProvider = jwtTokenProvider;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String jwt = JwtUtil.getJwtFromRequest(request, jwtTokenProvider);
+
+    Date tokenExpiry = jwtTokenProvider.jwsExpiry(jwt);
+    Duration timeToExpire = Duration
+        .between(LocalDate.now(), LocalDate.from(tokenExpiry.toInstant()));
+
+    if (timeToExpire.getSeconds() <= ONE_HOUR) {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+      User user = (User) authentication.getPrincipal();
+      String jws = jwtTokenProvider.generateJwsToken(user);
+
+      response.setHeader("jws", jws);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/arqaam/logframelab/configuration/security/jwt/JwtUtil.java
+++ b/src/main/java/com/arqaam/logframelab/configuration/security/jwt/JwtUtil.java
@@ -1,0 +1,21 @@
+package com.arqaam.logframelab.configuration.security.jwt;
+
+import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+
+public class JwtUtil {
+
+  private JwtUtil() {
+  }
+
+  public static String getJwtFromRequest(HttpServletRequest request,
+      JwtTokenProvider jwtTokenProvider) {
+    String bearerToken = request.getHeader(jwtTokenProvider.getTokenHeader());
+    if (StringUtils.isNotBlank(bearerToken) && bearerToken
+        .startsWith(jwtTokenProvider.getTokenHeaderPrefix())) {
+      return StringUtils.remove(bearerToken, jwtTokenProvider.getTokenHeaderPrefix());
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/arqaam/logframelab/controller/AuthController.java
+++ b/src/main/java/com/arqaam/logframelab/controller/AuthController.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -65,8 +64,7 @@ public class AuthController {
 
     String token = authService.generateToken(user);
     return ResponseEntity.ok(JwtAuthenticationTokenResponse.builder().token(token)
-        .tokenType(authService.getTokenType()).expiryDuration(
-            authService.getTokenExpiryInMillis())
+        .tokenType(authService.getTokenType())
         .groups(user.getGroupMembership().stream().map(m -> m.getGroup().getName()).collect(
             Collectors.toSet())).build());
   }

--- a/src/main/java/com/arqaam/logframelab/controller/dto/auth/login/JwtAuthenticationTokenResponse.java
+++ b/src/main/java/com/arqaam/logframelab/controller/dto/auth/login/JwtAuthenticationTokenResponse.java
@@ -15,6 +15,5 @@ import lombok.Setter;
 public class JwtAuthenticationTokenResponse {
   private String token;
   private String tokenType;
-  private Long expiryDuration;
   private Collection<String> groups;
 }

--- a/src/main/java/com/arqaam/logframelab/service/auth/AuthService.java
+++ b/src/main/java/com/arqaam/logframelab/service/auth/AuthService.java
@@ -14,7 +14,7 @@ public interface AuthService {
 
   String generateToken(User user);
 
-  Long getTokenExpiryInMillis();
+  Long getTokenExpiryInSeconds();
 
   String getTokenType();
 

--- a/src/main/java/com/arqaam/logframelab/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/arqaam/logframelab/service/auth/AuthServiceImpl.java
@@ -73,8 +73,8 @@ public class AuthServiceImpl  implements AuthService {
   }
 
   @Override
-  public Long getTokenExpiryInMillis() {
-    return tokenProvider.getJwtExpirationInMillis();
+  public Long getTokenExpiryInSeconds() {
+    return tokenProvider.getJwtExpirationInSeconds();
   }
 
   @Override

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -11,14 +11,9 @@
       "description": "Description for jwt.header.prefix."
     },
     {
-      "name": "jwt.expiration",
+      "name": "jwt.expiration.in.days",
       "type": "java.lang.String",
       "description": "Description for jwt.expiration."
-    },
-    {
-      "name": "jwt.claims.refresh.name",
-      "type": "java.lang.String",
-      "description": "Description for jwt.claims.refresh.name."
     }
   ]
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,8 +28,7 @@ spring.jpa.properties.hibernate.format_sql=true
 # Authorization
 jwt.header=Authorization
 jwt.header.prefix=Bearer 
-jwt.expiration=3600000
-jwt.claims.refresh.name=Refresh
+jwt.expiration.in.days=7
 
 # LogframeLab properties
 logframelab.world-bank-url=https://api.worldbank.org/v2/

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,4 +1,3 @@
 jwt.header=Authorization
 jwt.header.prefix=Bearer 
-jwt.expiration=3600000
-jwt.claims.refresh.name=Refresh
+jwt.expiration.in.days=7


### PR DESCRIPTION
[#6prc2g]

Longer expiry of JWT. 7 days, by default.
On each secure request, check that JWT is still more than 1 hour from expiry; if not, generate new JWT, and include in response header to client.